### PR TITLE
Implement WorkoutLogger

### DIFF
--- a/deliverables/WorkoutLogger.tsx
+++ b/deliverables/WorkoutLogger.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import { Controller } from 'react-hook-form'
+import { useWorkoutLogger } from './useWorkoutLogger'
+
+export function WorkoutLogger() {
+  const { form, onSubmit, error, exerciseOptions } = useWorkoutLogger()
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4 max-w-sm">
+      <Controller
+        control={form.control}
+        name="exerciseId"
+        render={({ field }) => (
+          <Select value={field.value} onValueChange={field.onChange}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select exercise" />
+            </SelectTrigger>
+            <SelectContent>
+              {exerciseOptions.map(opt => (
+                <SelectItem key={opt.id} value={opt.id}>
+                  {opt.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+      />
+      {form.formState.errors.exerciseId && (
+        <p className="text-sm text-red-500">
+          {form.formState.errors.exerciseId.message}
+        </p>
+      )}
+
+      <Input
+        type="number"
+        step="0.25"
+        min="0"
+        max="500"
+        placeholder="Weight (lbs)"
+        {...form.register('weight', { valueAsNumber: true })}
+      />
+      {form.formState.errors.weight && (
+        <p className="text-sm text-red-500">
+          {form.formState.errors.weight.message}
+        </p>
+      )}
+
+      <Input
+        type="number"
+        min="1"
+        max="50"
+        placeholder="Reps"
+        {...form.register('reps', { valueAsNumber: true })}
+      />
+      {form.formState.errors.reps && (
+        <p className="text-sm text-red-500">
+          {form.formState.errors.reps.message}
+        </p>
+      )}
+
+      {error && <p className="text-sm text-red-500">{error}</p>}
+
+      <Button type="submit" disabled={form.formState.isSubmitting}>
+        {form.formState.isSubmitting ? 'Saving...' : 'Save Set'}
+      </Button>
+    </form>
+  )
+}

--- a/deliverables/useWorkoutLogger.ts
+++ b/deliverables/useWorkoutLogger.ts
@@ -1,0 +1,48 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm, Controller } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import exercisesData from '@/data/exercises.json'
+import { workoutSetSchema, WorkoutSetInput } from './validation'
+
+interface ExerciseOption {
+  id: string
+  name: string
+}
+
+const exerciseOptions: ExerciseOption[] = (exercisesData as any[]).map(e => ({
+  id: e.id.toString(),
+  name: e.name as string
+}))
+
+export function useWorkoutLogger() {
+  const [error, setError] = useState<string | null>(null)
+
+  const form = useForm<WorkoutSetInput>({
+    resolver: zodResolver(workoutSetSchema),
+    defaultValues: { exerciseId: '', weight: 0, reps: 0 }
+  })
+
+  const onSubmit = form.handleSubmit(async values => {
+    setError(null)
+    try {
+      const res = await fetch('/api/workout-sets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values)
+      })
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.error || 'Failed to save workout set')
+      }
+
+      form.reset()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save workout set')
+    }
+  })
+
+  return { form, onSubmit, error, exerciseOptions }
+}

--- a/deliverables/validation.ts
+++ b/deliverables/validation.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod'
+
+export const workoutSetSchema = z.object({
+  exerciseId: z.string().min(1, 'Exercise is required'),
+  weight: z
+    .number({ invalid_type_error: 'Weight must be a number' })
+    .min(0, 'Weight must be at least 0')
+    .max(500, 'Weight must be 500 or less')
+    .refine(val => Number.isFinite(val) && val % 0.25 === 0, {
+      message: 'Weight must be in 0.25 lb increments'
+    }),
+  reps: z
+    .number({ invalid_type_error: 'Reps must be a number' })
+    .int('Reps must be an integer')
+    .min(1, 'Reps must be at least 1')
+    .max(50, 'Reps must be 50 or less')
+})
+
+export type WorkoutSetInput = z.infer<typeof workoutSetSchema>


### PR DESCRIPTION
## Summary
- add WorkoutLogger example solution per tasks
- provide useWorkoutLogger hook
- define workout logger validation schema

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68573980f86c832bacc5f5e5d50e8b9c