### PR TITLE
Add WorkoutLogger component deliverables

### DIFF
--- a/codex-tasks/001-workout-logger/deliverables/WorkoutLogger.tsx
+++ b/codex-tasks/001-workout-logger/deliverables/WorkoutLogger.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import exercises from '@/data/exercises.json'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form'
+import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select'
+import { useWorkoutLogger } from './useWorkoutLogger'
+
+interface WorkoutLoggerProps {
+  onLogged?: (data: any) => void
+}
+
+export function WorkoutLogger({ onLogged }: WorkoutLoggerProps) {
+  const { handleSubmit, submit, control, formState } = useWorkoutLogger(onLogged)
+
+  return (
+    <Form {...{ control }}>
+      <form onSubmit={handleSubmit(submit)} className="space-y-4">
+        <FormField
+          control={control}
+          name="exerciseId"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Exercise</FormLabel>
+              <Select onValueChange={field.onChange} value={field.value}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select exercise" />
+                </SelectTrigger>
+                <SelectContent>
+                  {exercises.map((ex) => (
+                    <SelectItem key={ex.id} value={ex.id.toString()}>
+                      {ex.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={control}
+          name="weight"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Weight (lbs)</FormLabel>
+              <FormControl>
+                <Input type="number" step="0.25" min="0" max="500" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={control}
+          name="reps"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Reps</FormLabel>
+              <FormControl>
+                <Input type="number" min="1" max="50" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <Button type="submit" disabled={formState.isSubmitting}>
+          {formState.isSubmitting ? 'Saving...' : 'Log Set'}
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/codex-tasks/001-workout-logger/deliverables/useWorkoutLogger.ts
+++ b/codex-tasks/001-workout-logger/deliverables/useWorkoutLogger.ts
@@ -1,0 +1,39 @@
+'use client'
+
+import { useCallback } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { workoutSetSchema, WorkoutSetInput } from './validation'
+
+export function useWorkoutLogger(onSuccess?: (data: any) => void) {
+  const form = useForm<WorkoutSetInput>({
+    resolver: zodResolver(workoutSetSchema),
+    defaultValues: {
+      exerciseId: '',
+      weight: 0,
+      reps: 0,
+    },
+  })
+
+  const submit = useCallback(
+    async (values: WorkoutSetInput) => {
+      const res = await fetch('/api/workout-sets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values),
+      })
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        throw new Error(err.error || 'Failed to save set')
+      }
+
+      const data = await res.json().catch(() => ({}))
+      onSuccess?.(data)
+      return data
+    },
+    [onSuccess]
+  )
+
+  return { ...form, submit }
+}

--- a/codex-tasks/001-workout-logger/deliverables/validation.ts
+++ b/codex-tasks/001-workout-logger/deliverables/validation.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod'
+
+export const workoutSetSchema = z.object({
+  exerciseId: z.string().nonempty('Exercise is required'),
+  weight: z
+    .number({ invalid_type_error: 'Weight is required' })
+    .min(0, 'Weight must be at least 0')
+    .max(500, 'Weight must be 500 lbs or less')
+    .refine((v) => Number.isInteger(v * 4), {
+      message: 'Weight must be in 0.25 lb increments',
+    }),
+  reps: z
+    .number({ invalid_type_error: 'Reps is required' })
+    .int('Reps must be a whole number')
+    .min(1, 'Reps must be at least 1')
+    .max(50, 'Reps must be 50 or less'),
+})
+
+export type WorkoutSetInput = z.infer<typeof workoutSetSchema>


### PR DESCRIPTION
## Summary
- create `WorkoutLogger` React component for logging sets
- add `useWorkoutLogger` hook to post sets
- define zod validation schema for workout sets

## Testing
- `npm run test:fast` *(fails: playwright not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68573980f86c832bacc5f5e5d50e8b9c