### PR TITLE
Add muscle heat map wild deliverables

### DIFF
--- a/codex-tasks/003-muscle-heat-map-wild/wild-deliverables/MuscleHeatMap.tsx
+++ b/codex-tasks/003-muscle-heat-map-wild/wild-deliverables/MuscleHeatMap.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { frontMuscles, backMuscles, MusclePath } from "./muscleSvgData"
+import { getHeatColor } from "./heatMapUtils"
+
+interface Exercise {
+  id: string
+  name: string
+  muscleEngagement: Record<string, number>
+}
+
+const dataPath = "../../../data/exercises.json"
+
+export default function MuscleHeatMap() {
+  const [exercises, setExercises] = useState<Exercise[]>([])
+  const [selectedId, setSelectedId] = useState<string>("1")
+  const [view, setView] = useState<"front" | "back">("front")
+
+  useEffect(() => {
+    fetch(dataPath)
+      .then((r) => r.json())
+      .then((d: Exercise[]) => setExercises(d))
+      .catch(() => {})
+  }, [])
+
+  const selected = exercises.find((e) => e.id === selectedId)
+  const engagement = selected?.muscleEngagement || {}
+
+  const renderMuscle = (m: MusclePath) => {
+    const percent = engagement[m.name] || 0
+    const color = percent ? getHeatColor(percent) : "#e5e7eb"
+    return (
+      <path
+        key={m.name}
+        d={m.path}
+        fill={color}
+        stroke="#1e293b"
+        strokeWidth={1}
+        style={{ transition: "fill 0.3s ease" }}
+      >
+        <title>
+          {m.name}: {percent}%
+        </title>
+      </path>
+    )
+  }
+
+  const muscles = view === "front" ? frontMuscles : backMuscles
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <select
+          value={selectedId}
+          onChange={(e) => setSelectedId(e.target.value)}
+          className="border rounded px-2 py-1 text-sm"
+        >
+          {exercises.map((ex) => (
+            <option key={ex.id} value={ex.id}>
+              {ex.name}
+            </option>
+          ))}
+        </select>
+        <button
+          className="border rounded px-2 py-1 text-sm"
+          onClick={() => setView(view === "front" ? "back" : "front")}
+        >
+          {view === "front" ? "Back" : "Front"}
+        </button>
+      </div>
+      <svg viewBox="0 0 350 420" className="w-full max-w-sm mx-auto">
+        {muscles.map(renderMuscle)}
+      </svg>
+    </div>
+  )
+}

--- a/codex-tasks/003-muscle-heat-map-wild/wild-deliverables/heatMapUtils.ts
+++ b/codex-tasks/003-muscle-heat-map-wild/wild-deliverables/heatMapUtils.ts
@@ -1,0 +1,18 @@
+/**
+ * Returns a heat map color for a given percentage.
+ * 0% -> cool blue, 100% -> hot red.
+ */
+export function getHeatColor(percent: number): string {
+  const clamped = Math.min(100, Math.max(0, percent))
+  const hue = (1 - clamped / 100) * 240 // 240 = blue, 0 = red
+  return `hsl(${hue}, 100%, 50%)`
+}
+
+/** Small helper to map engagement object to muscle colors */
+export function mapEngagementToColors(engagement: Record<string, number>): Record<string, string> {
+  const result: Record<string, string> = {}
+  Object.entries(engagement).forEach(([muscle, value]) => {
+    result[muscle] = getHeatColor(value)
+  })
+  return result
+}

--- a/codex-tasks/003-muscle-heat-map-wild/wild-deliverables/muscleSvgData.ts
+++ b/codex-tasks/003-muscle-heat-map-wild/wild-deliverables/muscleSvgData.ts
@@ -1,0 +1,25 @@
+export interface MusclePath {
+  name: string
+  path: string
+}
+
+export const frontMuscles: MusclePath[] = [
+  { name: 'Chest', path: 'M 145 110 L 205 110 L 210 140 L 200 155 L 175 165 L 150 155 L 140 140 Z' },
+  { name: 'Shoulders', path: 'M 120 95 L 145 95 L 150 115 L 145 125 L 125 120 L 115 105 Z' },
+  { name: 'Biceps', path: 'M 115 125 L 130 125 L 135 145 L 130 165 L 120 165 L 110 145 Z' },
+  { name: 'Forearms', path: 'M 105 190 L 120 190 L 115 210 L 105 210 L 100 200 Z' },
+  { name: 'Core', path: 'M 160 165 L 190 165 L 188 185 L 186 205 L 184 225 L 175 235 L 166 225 L 164 205 L 162 185 Z' },
+  { name: 'Quadriceps', path: 'M 145 255 L 175 255 L 170 280 L 168 305 L 165 330 L 155 335 L 152 305 L 150 280 Z' },
+  { name: 'Calves', path: 'M 145 335 L 165 335 L 162 360 L 158 380 L 152 380 L 148 360 Z' }
+]
+
+export const backMuscles: MusclePath[] = [
+  { name: 'Traps', path: 'M 140 60 L 210 60 L 220 90 L 205 120 L 175 130 L 145 120 L 130 90 Z' },
+  { name: 'Rear Delts', path: 'M 115 95 L 140 95 L 145 110 L 140 125 L 120 120 L 110 105 Z' },
+  { name: 'Triceps', path: 'M 110 125 L 125 125 L 130 145 L 125 165 L 115 165 L 105 145 Z' },
+  { name: 'Rhomboids', path: 'M 165 120 L 185 120 L 180 140 L 175 145 L 170 140 Z' },
+  { name: 'Lats', path: 'M 125 130 L 225 130 L 215 180 L 200 200 L 175 210 L 150 200 L 135 180 Z' },
+  { name: 'Glutes', path: 'M 140 250 L 210 250 L 205 280 L 195 295 L 175 300 L 155 295 L 145 280 Z' },
+  { name: 'Hamstrings', path: 'M 145 300 L 205 300 L 200 330 L 195 355 L 175 360 L 155 355 L 150 330 Z' },
+  { name: 'Calves', path: 'M 150 360 L 200 360 L 195 375 L 190 385 L 180 390 L 170 390 L 160 385 L 155 375 Z' }
+]


### PR DESCRIPTION
## Summary
- add wild muscle heat map component
- add color util functions for heat map
- add SVG path data for front/back muscles

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68574b6d1920832bad20da7274276908