### PR TITLE
Add AI Workout Generator

### DIFF
--- a/codex-tasks/README.md
+++ b/codex-tasks/README.md
@@ -32,7 +32,7 @@ cd codex-tasks/001-workout-logger
 ```
 
 ## Completed Tasks
-*None yet*
+- 004-ai-workout-generator
 
 ## Instructions for Codex
 

--- a/wild-deliverables/WorkoutGenerator.tsx
+++ b/wild-deliverables/WorkoutGenerator.tsx
@@ -1,0 +1,127 @@
+"use client"
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import type { UserPreferences, WorkoutPlan } from './workoutAlgorithms'
+import { generateWorkoutPlan } from './workoutAlgorithms'
+
+const defaultPrefs: UserPreferences = {
+  goal: 'general',
+  equipment: [],
+  time: 45,
+  experience: 'Beginner'
+}
+
+export default function WorkoutGenerator() {
+  const [prefs, setPrefs] = useState<UserPreferences>(defaultPrefs)
+  const [plan, setPlan] = useState<WorkoutPlan | null>(null)
+
+  const handleGenerate = () => {
+    setPlan(generateWorkoutPlan(prefs))
+  }
+
+  const updatePrefs = (key: keyof UserPreferences, value: any) => {
+    setPrefs(prev => ({ ...prev, [key]: value }))
+  }
+
+  return (
+    <Card className="max-w-xl">
+      <CardHeader>
+        <CardTitle>AI Workout Generator</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <Label>Goal</Label>
+            <Select value={prefs.goal} onValueChange={v => updatePrefs('goal', v)}>
+              <SelectTrigger>
+                <SelectValue placeholder="Goal" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="strength">Strength</SelectItem>
+                <SelectItem value="hypertrophy">Hypertrophy</SelectItem>
+                <SelectItem value="endurance">Endurance</SelectItem>
+                <SelectItem value="general">General Fitness</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label>Experience</Label>
+            <Select
+              value={prefs.experience}
+              onValueChange={v => updatePrefs('experience', v as any)}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Experience" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="Beginner">Beginner</SelectItem>
+                <SelectItem value="Intermediate">Intermediate</SelectItem>
+                <SelectItem value="Advanced">Advanced</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label>Time (minutes)</Label>
+            <Input
+              type="number"
+              value={prefs.time}
+              onChange={e => updatePrefs('time', Number(e.target.value) as any)}
+              min={30}
+            />
+          </div>
+          <div>
+            <Label>Equipment (comma separated)</Label>
+            <Input
+              type="text"
+              value={prefs.equipment.join(',')}
+              onChange={e =>
+                updatePrefs(
+                  'equipment',
+                  e.target.value
+                    .split(',')
+                    .map(s => s.trim())
+                    .filter(Boolean)
+                )
+              }
+            />
+          </div>
+        </div>
+        <Button onClick={handleGenerate}>Generate Workout</Button>
+
+        {plan && (
+          <div className="mt-4 space-y-2">
+            <h3 className="font-bold">Push</h3>
+            <ul className="list-disc list-inside">
+              {plan.push.map(ex => (
+                <li key={ex.id}>{ex.name}</li>
+              ))}
+            </ul>
+            <h3 className="font-bold">Pull</h3>
+            <ul className="list-disc list-inside">
+              {plan.pull.map(ex => (
+                <li key={ex.id}>{ex.name}</li>
+              ))}
+            </ul>
+            <h3 className="font-bold">Legs</h3>
+            <ul className="list-disc list-inside">
+              {plan.legs.map(ex => (
+                <li key={ex.id}>{ex.name}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/wild-deliverables/muscleBalanceLogic.ts
+++ b/wild-deliverables/muscleBalanceLogic.ts
@@ -1,0 +1,46 @@
+export interface Exercise {
+  id: string
+  name: string
+  category: string
+  equipment: string
+  difficulty: string
+  muscleEngagement: Record<string, number>
+}
+
+/**
+ * Select exercises while keeping overall muscle group distribution balanced.
+ * This is a lightweight heuristic that prevents selecting too many exercises
+ * for the same primary muscle group.
+ */
+export function selectExercisesBalanced(
+  exercises: Exercise[],
+  count: number
+): Exercise[] {
+  const selected: Exercise[] = []
+  const muscleCounts: Record<string, number> = {}
+  const candidates = [...exercises]
+
+  // Shuffle to add randomness
+  candidates.sort(() => Math.random() - 0.5)
+
+  while (selected.length < count && candidates.length) {
+    const ex = candidates.shift()!
+    const muscles = Object.keys(ex.muscleEngagement || {})
+    const minCount = Math.min(0, ...Object.values(muscleCounts))
+    const isBalanced = muscles.some(m => (muscleCounts[m] || 0) <= minCount)
+
+    if (isBalanced) {
+      selected.push(ex)
+      muscles.forEach(m => {
+        muscleCounts[m] = (muscleCounts[m] || 0) + 1
+      })
+    }
+  }
+
+  // If we didn't reach the desired count, fill with remaining exercises
+  while (selected.length < count && candidates.length) {
+    selected.push(candidates.shift()!)
+  }
+
+  return selected
+}

--- a/wild-deliverables/workoutAlgorithms.ts
+++ b/wild-deliverables/workoutAlgorithms.ts
@@ -1,0 +1,66 @@
+import exercises from '../data/exercises.json'
+import { Exercise, selectExercisesBalanced } from './muscleBalanceLogic'
+
+export type Goal = 'strength' | 'hypertrophy' | 'endurance' | 'general'
+
+export interface UserPreferences {
+  goal: Goal
+  equipment: string[]
+  time: 30 | 45 | 60
+  experience: 'Beginner' | 'Intermediate' | 'Advanced'
+  focus?: string
+}
+
+export interface WorkoutPlan {
+  push: Exercise[]
+  pull: Exercise[]
+  legs: Exercise[]
+}
+
+function filterByEquipment(list: Exercise[], equipment: string[]): Exercise[] {
+  if (equipment.length === 0) return list as Exercise[]
+  return list.filter(ex => {
+    if (!ex.equipment) return true
+    return (
+      equipment.includes(ex.equipment) ||
+      ex.equipment.toLowerCase() === 'bodyweight'
+    )
+  }) as Exercise[]
+}
+
+function filterByExperience(list: Exercise[], exp: string): Exercise[] {
+  return list.filter(ex => {
+    if (!ex.difficulty) return true
+    if (exp === 'Advanced') return true
+    if (exp === 'Intermediate') return ex.difficulty !== 'Advanced'
+    return ex.difficulty === 'Beginner'
+  }) as Exercise[]
+}
+
+function categorize(exercise: Exercise): 'push' | 'pull' | 'legs' {
+  const cat = exercise.category.toLowerCase()
+  if (cat.includes('chest') || cat.includes('triceps') || cat.includes('shoulder')) {
+    return 'push'
+  }
+  if (cat.includes('back') || cat.includes('biceps')) {
+    return 'pull'
+  }
+  return 'legs'
+}
+
+export function generateWorkoutPlan(prefs: UserPreferences): WorkoutPlan {
+  const base = filterByEquipment(exercises as Exercise[], prefs.equipment)
+  const eligible = filterByExperience(base, prefs.experience)
+
+  const pushEx = eligible.filter(e => categorize(e) === 'push')
+  const pullEx = eligible.filter(e => categorize(e) === 'pull')
+  const legEx = eligible.filter(e => categorize(e) === 'legs')
+
+  const exercisesPerGroup = prefs.time >= 60 ? 4 : prefs.time >= 45 ? 3 : 2
+
+  return {
+    push: selectExercisesBalanced(pushEx, exercisesPerGroup),
+    pull: selectExercisesBalanced(pullEx, exercisesPerGroup),
+    legs: selectExercisesBalanced(legEx, exercisesPerGroup)
+  }
+}


### PR DESCRIPTION
## Summary
- deliver new AI Workout Generator implementation as Task 004
- add supporting workout algorithms and muscle balance logic
- record completion in Codex tasks README

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68574baff9d0832bbfd9f10963c7e3ad