### PR TITLE
Add analytics dashboard deliverables

### DIFF
--- a/codex-tasks/006-analytics-dashboard/wild-deliverables/AnalyticsDashboard.tsx
+++ b/codex-tasks/006-analytics-dashboard/wild-deliverables/AnalyticsDashboard.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import { useState } from 'react'
+import ProgressLineChart from './chartComponents/ProgressLineChart'
+import MuscleBalanceRadar from './chartComponents/MuscleBalanceRadar'
+import type { WorkoutSet } from './dataProcessing'
+
+const sampleData: WorkoutSet[] = [
+  { exercise: 'Bench Press', weight: 185, reps: 5, date: '2024-05-01', muscles: { Chest: 70, Triceps: 30 } },
+  { exercise: 'Bench Press', weight: 190, reps: 5, date: '2024-05-08', muscles: { Chest: 70, Triceps: 30 } },
+  { exercise: 'Deadlift', weight: 315, reps: 3, date: '2024-05-10', muscles: { Back: 60, Legs: 40 } },
+  { exercise: 'Squat', weight: 225, reps: 5, date: '2024-05-12', muscles: { Legs: 80, Core: 20 } },
+  { exercise: 'Bench Press', weight: 195, reps: 5, date: '2024-05-15', muscles: { Chest: 70, Triceps: 30 } },
+  { exercise: 'Overhead Press', weight: 115, reps: 5, date: '2024-05-18', muscles: { Shoulders: 70, Triceps: 30 } },
+]
+
+export default function AnalyticsDashboard() {
+  const [data] = useState<WorkoutSet[]>(sampleData)
+
+  return (
+    <div className="space-y-8">
+      <h2 className="text-2xl font-semibold">Analytics Dashboard</h2>
+      <div className="grid gap-8 md:grid-cols-2">
+        <div>
+          <h3 className="mb-2 font-medium">Volume Progression</h3>
+          <ProgressLineChart data={data} />
+        </div>
+        <div>
+          <h3 className="mb-2 font-medium">Muscle Balance</h3>
+          <MuscleBalanceRadar data={data} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/codex-tasks/006-analytics-dashboard/wild-deliverables/chartComponents/MuscleBalanceRadar.tsx
+++ b/codex-tasks/006-analytics-dashboard/wild-deliverables/chartComponents/MuscleBalanceRadar.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { Radar, RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, ResponsiveContainer, Tooltip } from 'recharts'
+import type { WorkoutSet } from '../dataProcessing'
+import { muscleBalance } from '../dataProcessing'
+import { chartColors } from '../chartUtils'
+
+interface Props {
+  data: WorkoutSet[]
+}
+
+export default function MuscleBalanceRadar({ data }: Props) {
+  const chartData = muscleBalance(data)
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <RadarChart cx="50%" cy="50%" outerRadius="80%" data={chartData}>
+        <PolarGrid />
+        <PolarAngleAxis dataKey="muscle" />
+        <PolarRadiusAxis />
+        <Tooltip />
+        <Radar name="Engagement" dataKey="engagement" stroke={chartColors[1]} fill={chartColors[1]} fillOpacity={0.6} />
+      </RadarChart>
+    </ResponsiveContainer>
+  )
+}

--- a/codex-tasks/006-analytics-dashboard/wild-deliverables/chartComponents/ProgressLineChart.tsx
+++ b/codex-tasks/006-analytics-dashboard/wild-deliverables/chartComponents/ProgressLineChart.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
+import type { WorkoutSet } from '../dataProcessing'
+import { groupByDate } from '../dataProcessing'
+import { formatDate, chartColors } from '../chartUtils'
+
+interface Props {
+  data: WorkoutSet[]
+}
+
+export default function ProgressLineChart({ data }: Props) {
+  const chartData = groupByDate(data)
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <LineChart data={chartData} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="date" tickFormatter={formatDate} />
+        <YAxis />
+        <Tooltip labelFormatter={formatDate} />
+        <Line type="monotone" dataKey="volume" stroke={chartColors[0]} strokeWidth={2} />
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}

--- a/codex-tasks/006-analytics-dashboard/wild-deliverables/chartUtils.ts
+++ b/codex-tasks/006-analytics-dashboard/wild-deliverables/chartUtils.ts
@@ -1,0 +1,12 @@
+export function formatDate(date: string | number | Date): string {
+  return new Date(date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+export const chartColors = [
+  '#8884d8',
+  '#82ca9d',
+  '#ffc658',
+  '#ff7300',
+  '#d0ed57',
+  '#a4de6c',
+];

--- a/codex-tasks/006-analytics-dashboard/wild-deliverables/dataProcessing.ts
+++ b/codex-tasks/006-analytics-dashboard/wild-deliverables/dataProcessing.ts
@@ -1,0 +1,29 @@
+export interface WorkoutSet {
+  exercise: string
+  weight: number
+  reps: number
+  date: string
+  muscles: Record<string, number>
+}
+
+export function groupByDate(data: WorkoutSet[]) {
+  const map: Record<string, { volume: number; exercises: number }> = {}
+  data.forEach(item => {
+    if (!map[item.date]) {
+      map[item.date] = { volume: 0, exercises: 0 }
+    }
+    map[item.date].volume += item.weight * item.reps
+    map[item.date].exercises += 1
+  })
+  return Object.entries(map).map(([date, vals]) => ({ date, ...vals }))
+}
+
+export function muscleBalance(data: WorkoutSet[]) {
+  const muscleMap: Record<string, number> = {}
+  data.forEach(item => {
+    Object.entries(item.muscles).forEach(([muscle, pct]) => {
+      muscleMap[muscle] = (muscleMap[muscle] || 0) + pct
+    })
+  })
+  return Object.entries(muscleMap).map(([muscle, engagement]) => ({ muscle, engagement }))
+}


### PR DESCRIPTION
## Summary
- create wild deliverables for task 006 analytics dashboard
- implement small chart utilities and processing helpers
- add simple Recharts components
- add AnalyticsDashboard demo component

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68574bc8f22c832b99fcd7cb1fdf8cd0