### PR TITLE
Implement progressive overload calculator

### DIFF
--- a/codex-tasks/README.md
+++ b/codex-tasks/README.md
@@ -32,7 +32,7 @@ cd codex-tasks/001-workout-logger
 ```
 
 ## Completed Tasks
-*None yet*
+- 007-progressive-overload-calc ✅
 
 ## Instructions for Codex
 

--- a/wild-deliverables/ProgressiveOverloadCalc.tsx
+++ b/wild-deliverables/ProgressiveOverloadCalc.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import { useState } from "react"
+import {
+  linearProgression,
+  doubleProgression,
+  percentageBasedProgression,
+  autoRegulation,
+  WorkoutHistoryEntry,
+} from "./progressionAlgorithms"
+import { detectPlateau } from "./plateauDetection"
+
+interface ProgressiveOverloadCalcProps {
+  history: WorkoutHistoryEntry[]
+}
+
+export default function ProgressiveOverloadCalc({ history }: ProgressiveOverloadCalcProps) {
+  const last = history[history.length - 1]
+  const [method, setMethod] = useState("linear")
+  const [recommendation, setRecommendation] = useState<{ weight: number; reps: number }>({
+    weight: last?.weight || 0,
+    reps: last?.reps || 0,
+  })
+
+  const calculate = () => {
+    switch (method) {
+      case "linear":
+        setRecommendation({
+          weight: linearProgression(recommendation.weight, { weeklyIncrement: 2.5 }),
+          reps: recommendation.reps,
+        })
+        break
+      case "double":
+        setRecommendation(
+          doubleProgression(recommendation.weight, recommendation.reps, {
+            minReps: 5,
+            maxReps: 10,
+            weightIncrement: 2.5,
+          })
+        )
+        break
+      case "percentage":
+        setRecommendation({
+          weight: percentageBasedProgression(recommendation.weight, 2),
+          reps: recommendation.reps,
+        })
+        break
+      case "autoregulatory":
+        setRecommendation({
+          weight: autoRegulation(8, 9, recommendation.weight),
+          reps: recommendation.reps,
+        })
+        break
+      default:
+        break
+    }
+  }
+
+  const plateau = detectPlateau(history)
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-bold">Progressive Overload Calculator</h2>
+      {plateau && (
+        <p className="text-sm text-red-600">Plateau detected - consider a deload!</p>
+      )}
+      <div className="flex space-x-2">
+        <select value={method} onChange={(e) => setMethod(e.target.value)} className="border p-1">
+          <option value="linear">Linear</option>
+          <option value="double">Double</option>
+          <option value="percentage">Percentage</option>
+          <option value="autoregulatory">Auto Regulation</option>
+        </select>
+        <button onClick={calculate} className="px-2 py-1 border rounded">Calculate</button>
+      </div>
+      <div>
+        <p className="text-sm">Next Weight: {recommendation.weight} kg</p>
+        <p className="text-sm">Target Reps: {recommendation.reps}</p>
+      </div>
+    </div>
+  )
+}

--- a/wild-deliverables/plateauDetection.ts
+++ b/wild-deliverables/plateauDetection.ts
@@ -1,0 +1,22 @@
+import { WorkoutHistoryEntry } from './progressionAlgorithms'
+
+export function detectPlateau(
+  history: WorkoutHistoryEntry[],
+  window: number = 3,
+  threshold: number = 0.5
+): boolean {
+  if (history.length < window + 1) return false
+  const recent = history.slice(-window - 1)
+  const first = recent[0]
+  const last = recent[recent.length - 1]
+  const weightDiff = last.weight - first.weight
+  const repDiff = last.reps - first.reps
+  return weightDiff <= threshold && repDiff <= 0
+}
+
+export function recommendedDeload(
+  history: WorkoutHistoryEntry[],
+  plateauWindow: number = 3
+): boolean {
+  return detectPlateau(history, plateauWindow)
+}

--- a/wild-deliverables/progressionAlgorithms.ts
+++ b/wild-deliverables/progressionAlgorithms.ts
@@ -1,0 +1,68 @@
+export interface WorkoutHistoryEntry {
+  date: string
+  exercise: string
+  weight: number
+  reps: number
+}
+
+export interface LinearOptions {
+  weeklyIncrement: number
+}
+
+export function linearProgression(
+  currentWeight: number,
+  options: LinearOptions,
+  weeks: number = 1
+): number {
+  return currentWeight + options.weeklyIncrement * weeks
+}
+
+export interface DoubleProgressionOptions {
+  minReps: number
+  maxReps: number
+  weightIncrement: number
+}
+
+export function doubleProgression(
+  currentWeight: number,
+  currentReps: number,
+  options: DoubleProgressionOptions
+): { weight: number; reps: number } {
+  if (currentReps < options.maxReps) {
+    return {
+      weight: currentWeight,
+      reps: Math.min(currentReps + 1, options.maxReps),
+    }
+  }
+  return {
+    weight: currentWeight + options.weightIncrement,
+    reps: options.minReps,
+  }
+}
+
+export function percentageBasedProgression(
+  weight: number,
+  percentIncrease: number
+): number {
+  return Math.round(weight * (1 + percentIncrease / 100))
+}
+
+export function autoRegulation(
+  targetRpe: number,
+  actualRpe: number,
+  weight: number
+): number {
+  const diff = targetRpe - actualRpe
+  if (Math.abs(diff) < 0.5) {
+    return weight
+  }
+  const adjustment = weight * 0.015 * diff
+  return Math.max(weight + adjustment, 0)
+}
+
+export function periodizationSchedule(
+  baseWeight: number,
+  percentages: number[]
+): number[] {
+  return percentages.map((p) => Math.round(baseWeight * p))
+}

--- a/wild-deliverables/strengthCurves.ts
+++ b/wild-deliverables/strengthCurves.ts
@@ -1,0 +1,21 @@
+export type StrengthCurve = number[]
+
+export const defaultCurves: Record<string, StrengthCurve> = {
+  benchPress: [1, 0.95, 0.9, 0.85, 0.9, 0.95, 1],
+  squat: [1, 0.98, 0.95, 0.9, 0.95, 1],
+  deadlift: [1, 0.97, 0.94, 0.9, 0.95, 0.97, 1],
+}
+
+export function strengthMultiplier(
+  exercise: string,
+  position: number,
+  curves: Record<string, StrengthCurve> = defaultCurves
+): number {
+  const curve = curves[exercise]
+  if (!curve) return 1
+  const index = Math.min(
+    curve.length - 1,
+    Math.max(0, Math.round(position * (curve.length - 1)))
+  )
+  return curve[index]
+}


### PR DESCRIPTION
## Summary
- implement progression algorithms and helpers
- add progressive overload calculator component
- mark task 007 as completed in codex-tasks README

## Testing
- `npm test --silent` *(fails: jest not found)*
- `pytest backend/tests` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68574bd1ed34832b9904097a13c040e1